### PR TITLE
sdl2_mixer: remove opus and opusfile from used_api

### DIFF
--- a/recipes/src/sdl2_mixer/used_apis
+++ b/recipes/src/sdl2_mixer/used_apis
@@ -11,5 +11,3 @@ timer_session
 libflac
 libogg
 libvorbis
-opus
-opusfile


### PR DESCRIPTION
ref: genodelabs/genode-world@a6996fb59a1a71433e84482d09c911d1a86cb050